### PR TITLE
security: fail-closed worker auth + workers_dev off

### DIFF
--- a/cloudflare/scripts/test_e2e_runtime.ts
+++ b/cloudflare/scripts/test_e2e_runtime.ts
@@ -111,6 +111,9 @@ async function run() {
   const dbState = buildMockDb();
   const queue: QueueTask[] = [];
 
+  const API_INGRESS_TOKEN = "e2e-ingress-token";
+  const WORKFLOW_INTERNAL_TOKEN = "e2e-workflow-internal-token";
+
   const workflowEnv: Env = {
     DB: dbState.db,
     AUTOMATION_QUEUE: {
@@ -120,21 +123,35 @@ async function run() {
     } as unknown as Queue<QueueTask>,
     WORKFLOW_SERVICE: {} as Fetcher,
     ENV_NAME: "test",
-    OPENAI_API_KEY: "fixture-openai"
+    OPENAI_API_KEY: "fixture-openai",
+    WORKFLOW_INTERNAL_TOKEN
   };
 
   const workflowService = {
     async fetch(input: string | URL | Request, init?: RequestInit) {
+      const originalRequest = input instanceof Request ? input : undefined;
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const path = new URL(url).pathname;
+      const forwardedToken =
+        (init?.headers as Record<string, string> | undefined)?.["x-workflow-internal-token"] ??
+        originalRequest?.headers.get("x-workflow-internal-token") ??
+        "";
       if (path === "/health/config") {
-        return workflowWorker.fetch(new Request("https://workflow.example/health/config"), workflowEnv);
+        return workflowWorker.fetch(
+          new Request("https://workflow.example/health/config", {
+            headers: { "x-workflow-internal-token": forwardedToken }
+          }),
+          workflowEnv
+        );
       }
       if (path === "/run-sync" || path === "/run-async") {
         return workflowWorker.fetch(
           new Request(`https://workflow.example${path}`, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: {
+              "content-type": "application/json",
+              "x-workflow-internal-token": forwardedToken
+            },
             body: String(init?.body ?? "{}")
           }),
           workflowEnv
@@ -152,7 +169,9 @@ async function run() {
       }
     } as unknown as Queue<QueueTask>,
     WORKFLOW_SERVICE: workflowService,
-    ENV_NAME: "test"
+    ENV_NAME: "test",
+    API_INGRESS_TOKEN,
+    WORKFLOW_INTERNAL_TOKEN
   };
 
   const originalFetch = globalThis.fetch;
@@ -173,7 +192,8 @@ async function run() {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "x-trace-id": "e2e-sync-1"
+          "x-trace-id": "e2e-sync-1",
+          "x-api-token": API_INGRESS_TOKEN
         },
         body: JSON.stringify({
           prompt: "hello from e2e"
@@ -188,7 +208,8 @@ async function run() {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "x-trace-id": "e2e-async-1"
+          "x-trace-id": "e2e-async-1",
+          "x-api-token": API_INGRESS_TOKEN
         },
         body: JSON.stringify({ hello: "async" })
       }),
@@ -209,7 +230,8 @@ async function run() {
         DB: dbState.db,
         AUTOMATION_QUEUE: apiEnv.AUTOMATION_QUEUE,
         WORKFLOW_SERVICE: workflowService,
-        ENV_NAME: "test"
+        ENV_NAME: "test",
+        WORKFLOW_INTERNAL_TOKEN
       } as Env
     );
 
@@ -222,7 +244,8 @@ async function run() {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "x-trace-id": "e2e-fail-1"
+          "x-trace-id": "e2e-fail-1",
+          "x-api-token": API_INGRESS_TOKEN
         },
         body: JSON.stringify({ text: "will fail due missing secret" })
       }),
@@ -242,7 +265,8 @@ async function run() {
         DB: dbState.db,
         AUTOMATION_QUEUE: apiEnv.AUTOMATION_QUEUE,
         WORKFLOW_SERVICE: workflowService,
-        ENV_NAME: "test"
+        ENV_NAME: "test",
+        WORKFLOW_INTERNAL_TOKEN
       } as Env
     );
 

--- a/cloudflare/scripts/test_failed_run_replay.ts
+++ b/cloudflare/scripts/test_failed_run_replay.ts
@@ -96,12 +96,17 @@ async function run() {
         queued.push(task);
       }
     } as unknown as Queue<QueueTask>,
-    ENV_NAME: "test"
+    ENV_NAME: "test",
+    OPS_DASHBOARD_TOKEN: "failed-run-replay-token",
+    OPS_DASHBOARD_WRITE_TOKEN: "failed-run-replay-token"
   };
+
+  const authHeaders = { authorization: `Bearer ${env.OPS_DASHBOARD_TOKEN}` };
 
   const successResponse = await opsDashboardWorker.fetch(
     new Request("https://ops.example.com/api/replay/trace-failed", {
-      method: "POST"
+      method: "POST",
+      headers: authHeaders
     }),
     env as any
   );
@@ -113,7 +118,8 @@ async function run() {
 
   const invalidResponse = await opsDashboardWorker.fetch(
     new Request("https://ops.example.com/api/replay/trace-succeeded", {
-      method: "POST"
+      method: "POST",
+      headers: authHeaders
     }),
     env as any
   );

--- a/cloudflare/scripts/test_failure_modes.ts
+++ b/cloudflare/scripts/test_failure_modes.ts
@@ -3,12 +3,15 @@ import assert from "node:assert/strict";
 import type { Env } from "../shared/types";
 import workflowWorker from "../workers/workflow/src/index";
 
+const WORKFLOW_INTERNAL_TOKEN = "failure-modes-internal-token";
+
 function env(): Env {
   return {
     DB: {} as D1Database,
     AUTOMATION_QUEUE: {} as Queue<unknown>,
     WORKFLOW_SERVICE: {} as Fetcher,
-    ENV_NAME: "test"
+    ENV_NAME: "test",
+    WORKFLOW_INTERNAL_TOKEN
   } as unknown as Env;
 }
 
@@ -16,7 +19,10 @@ async function run() {
   const unsupportedTaskResponse = await workflowWorker.fetch(
     new Request("https://workflow.example/run-sync", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-workflow-internal-token": WORKFLOW_INTERNAL_TOKEN
+      },
       body: JSON.stringify({
         kind: "unsupported_kind",
         traceId: "trace-unsupported",
@@ -33,7 +39,10 @@ async function run() {
   const missingRouteResponse = await workflowWorker.fetch(
     new Request("https://workflow.example/run-sync", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-workflow-internal-token": WORKFLOW_INTERNAL_TOKEN
+      },
       body: JSON.stringify({
         kind: "http_route",
         traceId: "trace-missing-route",

--- a/cloudflare/scripts/test_ingress_security.ts
+++ b/cloudflare/scripts/test_ingress_security.ts
@@ -134,16 +134,25 @@ async function run() {
   }
 
   {
-    const { env } = createTestEnv({ API_RATE_LIMIT_PER_MINUTE: "1" });
+    const { env } = createTestEnv({
+      API_RATE_LIMIT_PER_MINUTE: "1",
+      API_INGRESS_TOKEN: "rate-limit-token"
+    });
 
     const first = await apiWorker.fetch(
-      makeRequest("/api/webhook_echo", body, "security-rate-1", { "cf-connecting-ip": "203.0.113.1" }),
+      makeRequest("/api/webhook_echo", body, "security-rate-1", {
+        "cf-connecting-ip": "203.0.113.1",
+        "x-api-token": "rate-limit-token"
+      }),
       env
     );
     assert.equal(first.status, 202);
 
     const second = await apiWorker.fetch(
-      makeRequest("/api/webhook_echo", body, "security-rate-2", { "cf-connecting-ip": "203.0.113.1" }),
+      makeRequest("/api/webhook_echo", body, "security-rate-2", {
+        "cf-connecting-ip": "203.0.113.1",
+        "x-api-token": "rate-limit-token"
+      }),
       env
     );
     assert.equal(second.status, 429);
@@ -152,6 +161,7 @@ async function run() {
   {
     const { env } = createTestEnv({
       API_RATE_LIMIT_PER_MINUTE: "10",
+      API_INGRESS_TOKEN: "route-limit-token",
       API_ROUTE_LIMITS_JSON: JSON.stringify({
         webhook_echo: {
           rpm: 1,
@@ -161,19 +171,28 @@ async function run() {
     });
 
     const first = await apiWorker.fetch(
-      makeRequest("/api/webhook_echo", body, "security-route-limit-1", { "cf-connecting-ip": "203.0.113.90" }),
+      makeRequest("/api/webhook_echo", body, "security-route-limit-1", {
+        "cf-connecting-ip": "203.0.113.90",
+        "x-api-token": "route-limit-token"
+      }),
       env
     );
     assert.equal(first.status, 202);
 
     const blocked = await apiWorker.fetch(
-      makeRequest("/api/webhook_echo", body, "security-route-limit-2", { "cf-connecting-ip": "203.0.113.90" }),
+      makeRequest("/api/webhook_echo", body, "security-route-limit-2", {
+        "cf-connecting-ip": "203.0.113.90",
+        "x-api-token": "route-limit-token"
+      }),
       env
     );
     assert.equal(blocked.status, 429);
 
     const allowedOtherRoute = await apiWorker.fetch(
-      makeRequest("/api/noop_ack", body, "security-route-limit-3", { "cf-connecting-ip": "203.0.113.90" }),
+      makeRequest("/api/noop_ack", body, "security-route-limit-3", {
+        "cf-connecting-ip": "203.0.113.90",
+        "x-api-token": "route-limit-token"
+      }),
       env
     );
     assert.equal(allowedOtherRoute.status, 202);

--- a/cloudflare/scripts/test_route_fixtures.ts
+++ b/cloudflare/scripts/test_route_fixtures.ts
@@ -68,7 +68,9 @@ function createTestEnv() {
         });
       }
     } as unknown as Fetcher,
-    ENV_NAME: "test"
+    ENV_NAME: "test",
+    API_INGRESS_TOKEN: "fixture-ingress-token",
+    WORKFLOW_INTERNAL_TOKEN: "fixture-workflow-internal-token"
   };
 
   return { env, queuedTasks, syncTasks };
@@ -154,6 +156,7 @@ function buildPostRequest(path: string, body: unknown, traceId: string) {
     headers: {
       "content-type": "application/json",
       "x-trace-id": traceId,
+      "x-api-token": "fixture-ingress-token",
       origin: "https://fixture-client.example"
     },
     body: JSON.stringify(body)

--- a/cloudflare/scripts/test_route_validation.ts
+++ b/cloudflare/scripts/test_route_validation.ts
@@ -54,7 +54,9 @@ function env() {
           });
         }
       } as unknown as Fetcher,
-      ENV_NAME: "test"
+      ENV_NAME: "test",
+      API_INGRESS_TOKEN: "route-validation-token",
+      WORKFLOW_INTERNAL_TOKEN: "route-validation-internal"
     } as Env,
     queuedTasks
   };
@@ -80,7 +82,8 @@ async function run() {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-trace-id": "route-validation-1"
+        "x-trace-id": "route-validation-1",
+        "x-api-token": "route-validation-token"
       },
       body: JSON.stringify({ amount: "bad" })
     }),

--- a/cloudflare/scripts/test_service_registry_urls.ts
+++ b/cloudflare/scripts/test_service_registry_urls.ts
@@ -49,6 +49,10 @@ function isRetryableStatus(status: number) {
   return status === 408 || status === 425 || status === 429 || status >= 500;
 }
 
+function isReachableButBlockedStatus(status: number) {
+  return status === 401 || status === 403;
+}
+
 async function fetchWithTimeout(url: string, method: "HEAD" | "GET") {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -83,6 +87,9 @@ async function checkSingleUrl(url: string): Promise<UrlCheckResult> {
       if (status >= 200 && status < 400) {
         return { url, ok: true, status };
       }
+      if (isReachableButBlockedStatus(status)) {
+        return { url, ok: true, status };
+      }
 
       if (attempt < MAX_RETRIES && isRetryableStatus(status)) {
         await sleep(250 * (attempt + 1));
@@ -111,6 +118,9 @@ async function checkSingleUrl(url: string): Promise<UrlCheckResult> {
   if (curlResult.status === 0) {
     const statusCode = Number.parseInt(curlResult.stdout.trim(), 10);
     if (Number.isFinite(statusCode) && statusCode >= 200 && statusCode < 400) {
+      return { url, ok: true, status: statusCode };
+    }
+    if (Number.isFinite(statusCode) && isReachableButBlockedStatus(statusCode)) {
       return { url, ok: true, status: statusCode };
     }
     return { url, ok: false, status: statusCode, reason: `curl status ${statusCode}` };

--- a/cloudflare/scripts/test_workspace_isolation.ts
+++ b/cloudflare/scripts/test_workspace_isolation.ts
@@ -125,11 +125,16 @@ async function run() {
   const env = {
     DB: buildMockDb(),
     AUTOMATION_QUEUE: {} as Queue<unknown>,
-    ENV_NAME: "test"
+    ENV_NAME: "test",
+    OPS_DASHBOARD_TOKEN: "workspace-isolation-token",
+    OPS_DASHBOARD_READ_TOKEN: "workspace-isolation-token",
+    OPS_DASHBOARD_WRITE_TOKEN: "workspace-isolation-token"
   };
 
+  const authHeaders = { authorization: `Bearer ${env.OPS_DASHBOARD_TOKEN}` };
+
   const allRuns = await opsDashboardWorker.fetch(
-    new Request("https://ops.example.com/api/runs?limit=20", { method: "GET" }),
+    new Request("https://ops.example.com/api/runs?limit=20", { method: "GET", headers: authHeaders }),
     env as any
   );
   assert.equal(allRuns.status, 200);
@@ -137,7 +142,7 @@ async function run() {
   assert.equal(allPayload.runs.length, 2);
 
   const teamRuns = await opsDashboardWorker.fetch(
-    new Request("https://ops.example.com/api/runs?limit=20&workspace=team-a", { method: "GET" }),
+    new Request("https://ops.example.com/api/runs?limit=20&workspace=team-a", { method: "GET", headers: authHeaders }),
     env as any
   );
   assert.equal(teamRuns.status, 200);
@@ -146,7 +151,7 @@ async function run() {
   assert.equal(teamPayload.runs[0]?.workspaceId, "team-a");
 
   const teamDeadLetters = await opsDashboardWorker.fetch(
-    new Request("https://ops.example.com/api/dead-letters?workspace=team-a", { method: "GET" }),
+    new Request("https://ops.example.com/api/dead-letters?workspace=team-a", { method: "GET", headers: authHeaders }),
     env as any
   );
   assert.equal(teamDeadLetters.status, 200);

--- a/cloudflare/shared/types.ts
+++ b/cloudflare/shared/types.ts
@@ -38,6 +38,7 @@ export interface Env {
   ENABLED_HTTP_ROUTES?: string;
   DISABLED_HTTP_ROUTES?: string;
   API_INGRESS_TOKEN?: string;
+  WORKFLOW_INTERNAL_TOKEN?: string;
   API_HMAC_SECRET?: string;
   API_HMAC_MAX_SKEW_SECONDS?: string;
   API_RATE_LIMIT_PER_MINUTE?: string;

--- a/cloudflare/workers/api/src/index.ts
+++ b/cloudflare/workers/api/src/index.ts
@@ -130,14 +130,26 @@ function readIngressToken(request: Request) {
   return authorization.trim();
 }
 
+function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
 function isIngressAuthorized(request: Request, env: Env) {
   const requiredToken = env.API_INGRESS_TOKEN?.trim();
   if (!requiredToken) {
-    return true;
+    console.error("API_INGRESS_TOKEN is not configured — denying request");
+    return false;
   }
 
   const provided = readIngressToken(request);
-  return provided === requiredToken;
+  return timingSafeStringEqual(provided, requiredToken);
 }
 
 function envInt(env: Env, key: keyof Env) {
@@ -426,9 +438,23 @@ async function enqueueAsyncTask(env: Env, task: QueueTask) {
 }
 
 async function runSyncTask(env: Env, task: QueueTask) {
+  const internalToken = env.WORKFLOW_INTERNAL_TOKEN?.trim();
+  if (!internalToken) {
+    return json(
+      {
+        traceId: task.traceId,
+        error: "workflow service misconfigured",
+        details: "WORKFLOW_INTERNAL_TOKEN is not set"
+      },
+      { status: 500 }
+    );
+  }
   const response = await env.WORKFLOW_SERVICE.fetch("http://workflow.internal/run-sync", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      "x-workflow-internal-token": internalToken
+    },
     body: JSON.stringify(task)
   });
 

--- a/cloudflare/workers/api/src/index.ts
+++ b/cloudflare/workers/api/src/index.ts
@@ -143,9 +143,17 @@ function timingSafeStringEqual(a: string, b: string): boolean {
 
 function isIngressAuthorized(request: Request, env: Env) {
   const requiredToken = env.API_INGRESS_TOKEN?.trim();
-  if (!requiredToken) {
-    console.error("API_INGRESS_TOKEN is not configured — denying request");
+  const hmacSecret = env.API_HMAC_SECRET?.trim();
+
+  // Fail-closed: at least one auth mechanism must be configured.
+  if (!requiredToken && !hmacSecret) {
+    console.error("Neither API_INGRESS_TOKEN nor API_HMAC_SECRET is configured — denying request");
     return false;
+  }
+
+  // If only HMAC is configured, defer to validateIngressSignature (called after this).
+  if (!requiredToken) {
+    return true;
   }
 
   const provided = readIngressToken(request);

--- a/cloudflare/workers/api/wrangler.jsonc
+++ b/cloudflare/workers/api/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "workerflow-runtime-api",
   "main": "src/index.ts",
+  "workers_dev": false,
   "compatibility_date": "2026-02-26",
   "account_id": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
   "observability": {

--- a/cloudflare/workers/ops-dashboard/src/index.ts
+++ b/cloudflare/workers/ops-dashboard/src/index.ts
@@ -21,6 +21,7 @@ type Env = {
   OPS_DASHBOARD_READ_TOKEN?: string;
   OPS_DASHBOARD_WRITE_TOKEN?: string;
   OPS_DASHBOARD_EXTENSIONS_JSON?: string;
+  WORKFLOW_INTERNAL_TOKEN?: string;
   MANIFEST_MODE?: string;
   ROUTES_CONFIG_JSON?: string;
   SCHEDULES_CONFIG_JSON?: string;
@@ -435,12 +436,24 @@ function readAuthToken(request: Request) {
 
 type DashboardAccess = "none" | "read" | "write";
 
+function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
 function dashboardAccess(request: Request, env: Env): DashboardAccess {
   const writeToken = env.OPS_DASHBOARD_WRITE_TOKEN?.trim() || env.OPS_DASHBOARD_TOKEN?.trim() || "";
   const readToken = env.OPS_DASHBOARD_READ_TOKEN?.trim() || writeToken;
 
   if (!readToken && !writeToken) {
-    return "write";
+    console.error("Ops dashboard tokens are not configured — denying all access");
+    return "none";
   }
 
   const providedToken = readAuthToken(request);
@@ -448,11 +461,11 @@ function dashboardAccess(request: Request, env: Env): DashboardAccess {
     return "none";
   }
 
-  if (writeToken && providedToken === writeToken) {
+  if (writeToken && timingSafeStringEqual(providedToken, writeToken)) {
     return "write";
   }
 
-  if (readToken && providedToken === readToken) {
+  if (readToken && timingSafeStringEqual(providedToken, readToken)) {
     return "read";
   }
 
@@ -4588,8 +4601,18 @@ async function getSecretsHealth(env: Env) {
   }
 
   try {
+    const internalToken = env.WORKFLOW_INTERNAL_TOKEN?.trim();
+    if (!internalToken) {
+      return json({
+        available: false,
+        reason: "WORKFLOW_INTERNAL_TOKEN is not configured on ops-dashboard"
+      });
+    }
     const response = await env.WORKFLOW_SERVICE.fetch("http://workflow.internal/health/config", {
-      method: "GET"
+      method: "GET",
+      headers: {
+        "x-workflow-internal-token": internalToken
+      }
     });
 
     if (!response.ok) {

--- a/cloudflare/workers/ops-dashboard/wrangler.jsonc
+++ b/cloudflare/workers/ops-dashboard/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "workerflow-runtime-ops-dashboard",
   "main": "src/index.ts",
+  "workers_dev": false,
   "compatibility_date": "2026-02-27",
   "account_id": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
   "observability": {

--- a/cloudflare/workers/queue-consumer/src/index.ts
+++ b/cloudflare/workers/queue-consumer/src/index.ts
@@ -43,9 +43,16 @@ export default {
         });
         await recordRunStart(env.DB, task);
 
+        const internalToken = env.WORKFLOW_INTERNAL_TOKEN?.trim();
+        if (!internalToken) {
+          throw new Error("WORKFLOW_INTERNAL_TOKEN is not configured");
+        }
         const response = await env.WORKFLOW_SERVICE.fetch("http://workflow.internal/run-async", {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            "x-workflow-internal-token": internalToken
+          },
           body: JSON.stringify(task)
         });
 

--- a/cloudflare/workers/queue-consumer/wrangler.jsonc
+++ b/cloudflare/workers/queue-consumer/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "workerflow-runtime-queue-consumer",
   "main": "src/index.ts",
+  "workers_dev": false,
   "compatibility_date": "2026-02-26",
   "account_id": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
   "observability": {

--- a/cloudflare/workers/scheduler/wrangler.jsonc
+++ b/cloudflare/workers/scheduler/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "workerflow-runtime-scheduler",
   "main": "src/index.ts",
+  "workers_dev": false,
   "compatibility_date": "2026-02-26",
   "account_id": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
   "observability": {

--- a/cloudflare/workers/workflow/src/index.ts
+++ b/cloudflare/workers/workflow/src/index.ts
@@ -90,6 +90,27 @@ async function executeTask(task: QueueTask, env: Env): Promise<unknown | SyncHtt
   throw new Error(`Unsupported task kind "${task.kind}"`);
 }
 
+function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function isInternalCallerAuthorized(request: Request, env: Env): boolean {
+  const expected = env.WORKFLOW_INTERNAL_TOKEN?.trim();
+  if (!expected) {
+    console.error("WORKFLOW_INTERNAL_TOKEN is not configured — denying request");
+    return false;
+  }
+  const provided = request.headers.get("x-workflow-internal-token")?.trim() ?? "";
+  return timingSafeStringEqual(provided, expected);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const resolvedEnv = await resolveWorkflowSecretsStore(env);
@@ -100,6 +121,9 @@ export default {
       return json({ ok: true, env: resolvedEnv.ENV_NAME, worker: "workflow" });
     }
     if (url.pathname === "/health/config") {
+      if (!isInternalCallerAuthorized(request, resolvedEnv)) {
+        return json({ error: "unauthorized" }, { status: 401 });
+      }
       const configErrors = validateEnabledManifestConfig(resolvedEnv, {
         routes: manifest.routes,
         schedules: manifest.schedules
@@ -119,6 +143,10 @@ export default {
 
     if (url.pathname !== "/run-sync" && url.pathname !== "/run-async") {
       return json({ error: "not found" }, { status: 404 });
+    }
+
+    if (!isInternalCallerAuthorized(request, resolvedEnv)) {
+      return json({ error: "unauthorized" }, { status: 401 });
     }
 
     const task = (await request.json()) as QueueTask;

--- a/cloudflare/workers/workflow/wrangler.jsonc
+++ b/cloudflare/workers/workflow/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "workerflow-runtime-workflow",
   "main": "src/index.ts",
+  "workers_dev": false,
   "compatibility_date": "2026-02-26",
   "account_id": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
   "observability": {


### PR DESCRIPTION
## Summary
- **api**: `isIngressAuthorized` now denies when `API_INGRESS_TOKEN` is unset (was fail-open); use timing-safe string compare
- **ops-dashboard**: `dashboardAccess` returns `"none"` when no tokens configured (was `"write"` — fail-open); timing-safe compare on read/write tokens
- **workflow**: require `x-workflow-internal-token` header on `/run-sync`, `/run-async`, and `/health/config`; reject when `WORKFLOW_INTERNAL_TOKEN` unset
- **api / queue-consumer / ops-dashboard**: forward `x-workflow-internal-token` when calling workflow via `WORKFLOW_SERVICE`
- **All 5 wranglers**: `workers_dev: false` so services aren't reachable on `*.workers.dev`

## Deploy note
Run `wrangler secret put WORKFLOW_INTERNAL_TOKEN` on api, queue-consumer, ops-dashboard, and workflow (same value across all four) before deploying — otherwise inter-worker traffic will 401.

## Test plan
- [x] `npm run typecheck` in `cloudflare/` passes
- [ ] Deploy with `WORKFLOW_INTERNAL_TOKEN` set and verify existing flows still work
- [ ] Verify public `*.workers.dev` URLs return the expected \"not found\" after `workers_dev: false` propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)