### PR TITLE
Guard production deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,9 @@ Use clear prefixes:
 - `chore:` maintenance/refactor/tooling
 
 Prefer small, reviewable commits with explicit impact.
+
+## Production operation boundary
+
+Local development, release checks, fixture tests, and builds may run without confirmation. Deploying any Worker or Pages project, applying remote migrations, changing production bindings, routes, or Cloudflare secrets, or running a production smoke test that mutates state requires an explicit request for that exact operation and fresh human approval.
+
+Use the guarded `npm run deploy:*` commands for approved deployments. Do not bypass the repository's approval scripts with raw Wrangler commands. Keep public configs placeholder-based, keep credentials in Cloudflare secrets or ignored local files, and never let tests fall back to production services or data.

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -52,11 +52,11 @@
     "dev:scheduler": "wrangler dev --config workers/scheduler/wrangler.jsonc",
     "dev:queue": "wrangler dev --config workers/queue-consumer/wrangler.jsonc",
     "dev:workflow": "wrangler dev --config workers/workflow/wrangler.jsonc",
-    "deploy:api": "wrangler deploy --config workers/api/wrangler.jsonc",
-    "deploy:ops": "wrangler deploy --config workers/ops-dashboard/wrangler.jsonc",
-    "deploy:scheduler": "wrangler deploy --config workers/scheduler/wrangler.jsonc",
-    "deploy:queue": "wrangler deploy --config workers/queue-consumer/wrangler.jsonc",
-    "deploy:workflow": "wrangler deploy --config workers/workflow/wrangler.jsonc"
+    "deploy:api": "bash scripts/deploy-production.sh api",
+    "deploy:ops": "bash scripts/deploy-production.sh ops",
+    "deploy:scheduler": "bash scripts/deploy-production.sh scheduler",
+    "deploy:queue": "bash scripts/deploy-production.sh queue",
+    "deploy:workflow": "bash scripts/deploy-production.sh workflow"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260629.1",

--- a/cloudflare/scripts/deploy-production.sh
+++ b/cloudflare/scripts/deploy-production.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+component="${1:-}"
+if [[ -z "${component}" ]]; then
+  echo "Usage: $0 <api|ops|scheduler|queue|workflow> [wrangler arguments]" >&2
+  exit 2
+fi
+shift
+
+case "${component}" in
+  api) config="workers/api/wrangler.jsonc" ;;
+  ops) config="workers/ops-dashboard/wrangler.jsonc" ;;
+  scheduler) config="workers/scheduler/wrangler.jsonc" ;;
+  queue) config="workers/queue-consumer/wrangler.jsonc" ;;
+  workflow) config="workers/workflow/wrangler.jsonc" ;;
+  *) echo "Unknown WorkerFlow component: ${component}" >&2; exit 2 ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${script_dir}/require-production-approval.sh" "deploy the WorkerFlow ${component} Worker" "Cloudflare production"
+
+exec npx wrangler deploy --config "${config}" "$@"

--- a/cloudflare/scripts/require-production-approval.sh
+++ b/cloudflare/scripts/require-production-approval.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+operation="${1:-production operation}"
+target="${2:-Cloudflare production}"
+
+if [[ ! -t 0 || ! -t 1 ]]; then
+  echo "Refusing ${operation} against ${target}: an interactive terminal and fresh human approval are required." >&2
+  exit 1
+fi
+
+echo "Production approval required"
+echo "Operation: ${operation}"
+echo "Target:    ${target}"
+
+sudo -k
+sudo -v -p "Approve this production operation with Touch ID or an administrator password: "
+sudo -K

--- a/pages-dashboard/package.json
+++ b/pages-dashboard/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest",
     "preview": "vite preview",
     "release:check": "npm run lint && npm run test && npm run build",
-    "deploy:pages": "npm run build && wrangler pages deploy dist --project-name workerflow-dashboard"
+    "deploy:pages": "npm run build && bash scripts/deploy-production.sh"
   },
   "dependencies": {
     "@fontsource/fraunces": "^5.2.9",

--- a/pages-dashboard/scripts/deploy-production.sh
+++ b/pages-dashboard/scripts/deploy-production.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${script_dir}/../../cloudflare/scripts/require-production-approval.sh" "deploy the WorkerFlow dashboard" "workerflow-dashboard production Pages project"
+
+exec npx wrangler pages deploy dist --project-name workerflow-dashboard "$@"


### PR DESCRIPTION
Adds interactive human-presence approval gates to every Worker and Pages production deploy entry point. Local checks and release validation remain unchanged; no deployment is performed by this change.