### PR TITLE
fix: update dashboard undici override

### DIFF
--- a/pages-dashboard/package-lock.json
+++ b/pages-dashboard/package-lock.json
@@ -5478,9 +5478,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/pages-dashboard/package.json
+++ b/pages-dashboard/package.json
@@ -49,6 +49,6 @@
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",
     "flatted": "^3.4.1",
-    "undici": "^7.24.3"
+    "undici": "^7.29.0"
   }
 }


### PR DESCRIPTION
## What changed

- raises the pages dashboard undici override from ^7.24.3 to ^7.29.0
- regenerates only the dashboard lockfile
- resolves all five current undici Dependabot alerts

## Verification

- npm ci
- npm explain undici (7.29.0)
- npm run release:check

No production deployment is triggered by this PR.