### PR TITLE
fix: update dashboard PostCSS override

### DIFF
--- a/pages-dashboard/package-lock.json
+++ b/pages-dashboard/package-lock.json
@@ -4696,9 +4696,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4716,7 +4716,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/pages-dashboard/package.json
+++ b/pages-dashboard/package.json
@@ -49,6 +49,7 @@
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",
     "flatted": "^3.4.1",
+    "postcss": "^8.5.23",
     "undici": "^7.29.0"
   }
 }


### PR DESCRIPTION
Fixes Dependabot alert #55 by adding a narrow dashboard override for PostCSS 8.5.23 or later. The regenerated lockfile resolves PostCSS 8.5.25; no runtime or application code changes.

Validation:
- npm explain postcss -> 8.5.25
- npm run release:check
- git diff --check

No Cloudflare deployment is included.