### PR TITLE
fix: update dashboard brace-expansion override

### DIFF
--- a/pages-dashboard/package-lock.json
+++ b/pages-dashboard/package-lock.json
@@ -2983,16 +2983,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/pages-dashboard/package.json
+++ b/pages-dashboard/package.json
@@ -47,6 +47,7 @@
   },
   "overrides": {
     "@babel/core": "7.29.6",
+    "brace-expansion": "^5.0.9",
     "esbuild": "0.28.1",
     "flatted": "^3.4.1",
     "postcss": "^8.5.23",


### PR DESCRIPTION
Resolves the dashboard npm audit finding by adding a narrow brace-expansion 5.0.9-or-later override. The regenerated lockfile resolves brace-expansion 5.0.9; no runtime or application code changes.

Validation:
- npm explain brace-expansion -> 5.0.9
- npm audit -> 0 vulnerabilities
- npm run release:check
- git diff --check

No Cloudflare deployment is included.